### PR TITLE
Multi language support

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/jenkins.rb
+++ b/lib/capistrano/recipes/deploy/scm/jenkins.rb
@@ -118,14 +118,18 @@ module Capistrano
 
         def rss_all
           begin
-            @rss_all ||= open(repository + '/rssAll', auth_opts).read()
+            @rss_all ||= open(repository + '/rssAll', accept_language.merge(auth_opts)).read()
           rescue => e
             raise Capistrano::Error, "open url #{repository + '/rssAll'} failed: #{e}"
           end
         end
 
         def rss_changelog
-          @rss_changelog ||= open(repository + '/rssChangelog', auth_opts).read()
+          @rss_changelog ||= open(repository + '/rssChangelog', accept_language.merge(auth_opts)).read()
+        end
+
+        def accept_language
+          {"Accept-Language" => "en-US"}
         end
 
         def auth_opts


### PR DESCRIPTION
Since Jenkins returns the rss feed based on the Accept-Language header,  it needs to be specified as en-US.

For example, with Japanese PC,  Jenkins returns the following xml for rssAll 

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <title>example-project all builds</title>
  <link type="text/html" href="http://example.com/jenkins/job/example-project/" rel="alternate"/>
  <updated>2012-06-12T10:03:09Z</updated>
  <author>
    <name>Jenkins Server</name>
  </author>
  <id>urn:uuid:903deee0-7bfa-11db-9fe1-0800200c9a66</id>
  <entry>
    <title>example-project #85 (安定)</title>
    <link type="text/html" href="http://example.com/jenkins/job/example-project/85/" rel="alternate"/>
    <id>tag:hudson.dev.java.net,2012:example-project:2012-06-12_19-03-09</id>
    <published>2012-06-12T10:03:09Z</published>
    <updated>2012-06-12T10:03:09Z</updated>
  </entry>
  <entry>
    <title>example-project #84 (不安定)</title>
    <link type="text/html" href="http://example.com/jenkins/job/example-project/84/" rel="alternate"/>
    <id>tag:hudson.dev.java.net,2012:example-project:2012-06-06_14-05-07</id>
    <published>2012-06-06T05:05:07Z</published>
    <updated>2012-06-06T05:05:07Z</updated>
  </entry>
</feed>
```
