### PR TITLE
Added Windows support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     capistrano-scm-jenkins (0.0.4)
       capistrano
       net-netrc
+      rubyzip
 
 GEM
   remote: http://rubygems.org/
@@ -35,9 +36,11 @@ GEM
     rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.10.1)
+    rubyzip (0.9.9)
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   capistrano-scm-jenkins!

--- a/capistrano-scm-jenkins.gemspec
+++ b/capistrano-scm-jenkins.gemspec
@@ -24,6 +24,7 @@ deploy your build artifact with capistrano.
   # specify any dependencies here; for example:
   s.add_runtime_dependency "capistrano"
   s.add_runtime_dependency "net-netrc"
+  s.add_runtime_dependency "rubyzip"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
- Use open-uri to download files if jenkins_use_netrc not defined
- Unzip files with rubyzip
- Trick Capistrano into thinking some non-existant cmds passed
