### PR TITLE
Cross platform fix

### DIFF
--- a/lib/capistrano/recipes/deploy/scm/jenkins.rb
+++ b/lib/capistrano/recipes/deploy/scm/jenkins.rb
@@ -57,7 +57,7 @@ module Capistrano
           # HACK: rather than using shell commands to download / extract and
           # move files, use something cross platform, and fake a shell success
           # this does break the benchmarking of the system call, but oh well
-          return 'exit 0'
+          return 'true'
         end
 
         alias_method :export, :checkout


### PR DESCRIPTION
Sorry, Bash was not happy with `exit 0` --- this works on Windows and Bash.  Might want to verify OSX since I don't have access to it.
