### PR TITLE
bypass ssl verification when obtaining jenkins artifact with curl

### DIFF
--- a/lib/capistrano/jenkins.rb
+++ b/lib/capistrano/jenkins.rb
@@ -125,7 +125,8 @@ class Capistrano::Jenkins < Capistrano::SCM
     def update
       # grab the newest artifact
       context.execute :curl, "--silent --fail --show-error #{curl_auth} " +
-        "#{artifact_url} -o #{fetch(:application)}#{artifact_ext}"
+        "#{artifact_url} -o #{fetch(:application)}#{artifact_ext} " +
+        "#{"--insecure" if fetch(:jenkins_insecure)}"
     end
 
     def release


### PR DESCRIPTION
Although using `set :jenkins_insecure, true`, cURL returns an SSL error.
This is easy to fix if the jenkins_insecure flag adds the `--insecure` param to cURL.
